### PR TITLE
fixed keycard not going to inventory area

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -657,7 +657,7 @@ Transform:
   m_GameObject: {fileID: 890403202}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.0809801, w: 0.9967158}
-  m_LocalPosition: {x: 7.26, y: 1.81, z: -0.16}
+  m_LocalPosition: {x: 6.42, y: 1.94, z: -0.16}
   m_LocalScale: {x: 0.12, y: 0.12, z: 0.12}
   m_ConstrainProportionsScale: 1
   m_Children: []

--- a/Assets/Scripts/CursorScripts/FollowMouse.cs
+++ b/Assets/Scripts/CursorScripts/FollowMouse.cs
@@ -4,29 +4,23 @@ using UnityEngine;
 
 public class FollowMouse : MonoBehaviour
 {
-    // Start is called before the first frame update
     void Start()
     {
-        //Debug.Log("FollowMouse just started");
-        this.enabled = false;
+        Debug.Log("FollowMouse just started");
     }
 
-    // Update is called once per frame
+
     void Update()
     {
         HaveIconFollowCursor();
     }
 
+
     public void HaveIconFollowCursor()
     {
+        this.enabled = true;
         Vector3 mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         mousePosition.z = Camera.main.transform.position.z + Camera.main.nearClipPlane;
         transform.position = mousePosition;
-    }
-
-    public void OnMouseDown()
-    {
-        // this isn't being called after the inventory item is attached to the cursor
-        //Debug.Log("OnMouseDown inside FollowMouse.cs");
     }
 }

--- a/Assets/Scripts/InventoryScripts/ActiveInventoryItem.cs
+++ b/Assets/Scripts/InventoryScripts/ActiveInventoryItem.cs
@@ -10,17 +10,13 @@ public static class ActiveInventoryItem
 
     public static void SetCurrentActiveInventoryItem(string passedInValue)
     {
-        //Debug.Log("inside SetCurrentActiveInventoryItem(): " + passedInValue);
         currentActiveInventoryItem = passedInValue;
-        Debug.Log("GetCurrentActiveInventoryItem() inside the set method" + GetCurrentActiveInventoryItem());
     }
 
 
     public static string GetCurrentActiveInventoryItem()
     {
         string valueToReturn = currentActiveInventoryItem;
-        //Debug.Log("inside GetCurrentActiveInventoryItem()");
-        Debug.Log("currentActiveInventoryItem should be returning: " + valueToReturn);
         return valueToReturn;
     }
 }

--- a/Assets/Scripts/InventoryScripts/InventoryItem.cs
+++ b/Assets/Scripts/InventoryScripts/InventoryItem.cs
@@ -4,38 +4,23 @@ using UnityEngine;
 
 public class InventoryItem : MonoBehaviour
 {
-
     public string itemName = "";
     public string itemDescription = "";
-    //public string activeInventoryItem = "";
 
     public GameObject DynamicItemName;
     public GameObject DynamicItemDescription;
     public FollowMouse followMousescript;
-    // try Finding it instead of this method
-    //public ActiveInventoryItem activeInventoryItem;
-
-    //ReferencedScript refScript = GetComponent<ReferencedScript>();
-    
 
 
     void Start()
     {
         this.enabled = false;
-        //ActiveInventoryItem activeInventoryItemScript = GetComponent<ActiveInventoryItem>();
-    }
-
-
-    void Update()
-    {
-        // make the icon stick to the cursor here?
     }
 
 
     public void OnMouseEnter()
     {
         DynamicItemName.GetComponent<UnityEngine.UI.Text>().text = itemName;
-        //Debug.Log("InventoryItem onMouseEnter");
     }
 
 
@@ -43,45 +28,27 @@ public class InventoryItem : MonoBehaviour
     {
         DynamicItemName.GetComponent<UnityEngine.UI.Text>().text = "";
         DynamicItemDescription.GetComponent<UnityEngine.UI.Text>().text = "";
-        //Debug.Log("InventoryItem onMouseExit");
     }
+
 
     public void OnMouseDown()
     {
         if(itemName == "Keycard")
         {
-            AttachKeyCardToCursor();
             ActiveInventoryItem.SetCurrentActiveInventoryItem("Keycard");
+            AttachKeyCardToCursor();
         }
-
-        
-
-        // how to know what item is attached to cursor?
-        // if you click on the door hotspot with the keycard attached to your cursor, yay you win
     }
 
 
     public void OnMouseUp()
     {
         DynamicItemDescription.GetComponent<UnityEngine.UI.Text>().text = itemDescription;
-        //Debug.Log("you clicked on: " + itemName + " in the inventory!");
-        
     }
+
 
     public void AttachKeyCardToCursor()
     {
-        //Debug.Log("attach " + itemName + " to cursor");
-        followMousescript.enabled = true;
         followMousescript.HaveIconFollowCursor();
-
-        // this "works" but only moves when you click. doesn't follow cursor
-        /*
-        Vector3 mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-        mousePosition.z = Camera.main.transform.position.z + Camera.main.nearClipPlane;
-        transform.position = mousePosition;
-        */
     }
-
-
-
 }

--- a/Assets/Scripts/ItemScripts/AdvanceThroughGame.cs
+++ b/Assets/Scripts/ItemScripts/AdvanceThroughGame.cs
@@ -5,45 +5,23 @@ using UnityEngine;
 
 public class AdvanceThroughGame : MonoBehaviour
 {
-    // needs to know about door hotspot
-    //public GameObject doorHotspot;
-    // needs to know about activeInventoryItem
-    //public ActiveInventoryItem activeInventoryItem;
-
-    //GameObject.
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
+    // this class is attached to the door hotspot which for this room (Lobby) is the "win condition";
+    // it would make sense for each room to have it's own standalone file like
     public void OnMouseDown()
     {
         Debug.Log("inside advanceThroughGame class");
-        string value = ActiveInventoryItem.GetCurrentActiveInventoryItem();
-        //string value = activeInventoryItem.GetCurrentActiveInventoryItem();
-        //string value = activeInventoryItem.currentActiveInventoryItem;
+        string currentSelectedInventoryItem = ActiveInventoryItem.GetCurrentActiveInventoryItem();
 
-        Debug.Log("value: " + value);
-
-        if(value == "")
+        if(currentSelectedInventoryItem == "")
         {
-            Debug.Log("the value for active inventoryItem was a empty string");
-            //return;
+            return;
         }
         else
         {
-            //Debug.Log("the value for active inventoryItem was NOT an empty string and we'rein the else statement");
-            if (value == "Keycard")
+            if (currentSelectedInventoryItem == "Keycard")
             {
                 Debug.Log("yahoo. You win the room");
+                // advance to next scene
             }
         }
 

--- a/Assets/Scripts/ItemScripts/InteractiveItem.cs
+++ b/Assets/Scripts/ItemScripts/InteractiveItem.cs
@@ -21,17 +21,15 @@ public class NewBehaviourScript : MonoBehaviour
     public void OnMouseEnter()
     {
         DynamicItemName.GetComponent<UnityEngine.UI.Text>().text = itemName;
-        //Debug.Log("onMouseEnter in InteractiveItem");
     }
 
 
-    // clears dynamicItemName
+    // clears out dynamicItemName and dynamicItemDesciption
     public void OnMouseExit()
     {
+
         DynamicItemName.GetComponent<UnityEngine.UI.Text>().text = "";
-        // this also clears out the desciption; need to find a way to fade this out instead
         DynamicItemDescription.GetComponent<UnityEngine.UI.Text>().text = "";
-        //Debug.Log("onMouseExit in InteractiveItem");
     }
 
 
@@ -45,12 +43,8 @@ public class NewBehaviourScript : MonoBehaviour
             // this conditional is comparing the names over in the Hierarchy
             if(this.name == "keycard-from-play-area")
             {
-                //Debug.Log("the item you clicked was named Keycard. Turn this off and turn on the inventory keycard");
                 itemFromGamePlayAreaToInventoryScript.TransitionKeycardFromGamePlayAreaToInventory();
             }
         }
     }
-
-
-
 }

--- a/Assets/Scripts/ItemScripts/ItemFromGamePlayAreaToInventory.cs
+++ b/Assets/Scripts/ItemScripts/ItemFromGamePlayAreaToInventory.cs
@@ -14,9 +14,8 @@ public class ItemFromGamePlayAreaToInventory : MonoBehaviour
 
     public void TransitionKeycardFromGamePlayAreaToInventory()
     {
+        Debug.Log("TransitionKeycardFromGamePlayAreaToInventory() in ItemFromGameplayAreaToInventory");
         KeycardFromPlayArea.SetActive(false);
         KeycardInInventory.SetActive(true);
     }
-
-
 }


### PR DESCRIPTION
- fixed the issue with the keycard not going to the inventory area after being clicked; it had something to do with the FollowMouse script starting too early then being disabled after the first frame; turned off the follow script component in the editor so it doesn't fire up until one of its methods is called

- cleaned up code