### PR TITLE
disabled FollowMouse script on startup

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2010,7 +2010,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2039840093}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8235839b04122d54699838f356519546, type: 3}
   m_Name: 


### PR DESCRIPTION
- FollowMouse script is disabled in the inspector for startup
- item goes to inventory first, then must be clicked on before following the cursor